### PR TITLE
Create installation wizard

### DIFF
--- a/installer/info/license.txt
+++ b/installer/info/license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Colin Hartigan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/installer/info/pre-install.txt
+++ b/installer/info/pre-install.txt
@@ -1,0 +1,13 @@
+VIM (VALORANT Inventory Manager)
+--------------------------------
+
+Thanks for installing VIM!
+
+This application provides powerful features for managing your Valorant collection and inventory:
+
++ Set favorite skins.
++ Randomize your skins every match.
++ Better design and interface than Valorant's.
+
+NOTE: VIM DOES NOT UNLOCK SKINS FOR FREE.
+This is not a cheat or hack, you can only manage skins you own.

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,0 +1,53 @@
+#define MyAppName "VALORANT Inventory Manager"
+#define MyAppVersion "1.0.0b3"
+#define MyAppPublisher "colinhartigan"
+#define MyAppURL "https://github.com/colinhartigan/valorant-inventory-manager/"
+#define MyAppExeName "VIM.exe"
+
+[Setup]
+AppId={{EC6B5079-8072-43DA-AD7E-106F4659E381}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+;AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+DisableProgramGroupPage=yes
+LicenseFile=info\license.txt
+InfoBeforeFile=info\pre-install.txt
+; Remove the following line to run in administrative install mode (install for all users.)
+PrivilegesRequired=lowest
+OutputDir=build
+OutputBaseFilename=setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+
+[Code]
+procedure StartBrowserClient();
+var
+  ResultCode: Integer;
+begin
+  Exec('cmd.exe', '/c START /WAIT VIM.exe; START /MAX https://colinhartigan.github.io/valorant-inventory-manager', '', SW_HIDE, ewNoWait, ResultCode);
+end;
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "french"; MessagesFile: "compiler:Languages\French.isl"
+Name: "german"; MessagesFile: "compiler:Languages\German.isl"
+Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "..\dists\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -69,7 +69,8 @@ class Server:
         #start websocket server
         start_server = websockets.serve(Server.ws_entrypoint, "", 8765)
         
-        print(f"server running\nopen {'https://colinhartigan.github.io/valorant-inventory-manager' if not IS_TEST_BUILD else 'https://colinhartigan.github.io/VIM-test-client'} in your browser to use VIM")
+        print(f"server running!\nopen {'https://colinhartigan.github.io/valorant-inventory-manager' if not IS_TEST_BUILD else 'https://colinhartigan.github.io/VIM-test-client'} in your browser to use VIM")
+        os.system("START /MAX https://colinhartigan.github.io/valorant-inventory-manager")
         shared.loop.run_until_complete(start_server)
 
         # initialize any asynchronous submodules


### PR DESCRIPTION
Uses [Inno Setup]() to provide an installation wizard for VIM. Greatly simplifies the installation process and has great supporting features like adding a shortcut to desktop, installation languages, etc.

Tested on Windows 10 (x64) [0.0.19044 Build 19044]

Here's a demo:

https://user-images.githubusercontent.com/62220201/162851171-9bde291b-98bd-4e19-9b9a-7d863bd8f36c.mp4

**Developement:**

+ Adds the `installer/` directory to the project.
+ Steps to build the setup script:
    1. Get the Inno Setup IDE/Compiler from the [Downloads Page](https://jrsoftware.org/isdl.php)
    2. Once downloaded, open `installer/setup.iss` in the Inno Setup IDE.
    3. Build an installation executable to `installer/build` by compiling the script in the editor:

        ![image](https://user-images.githubusercontent.com/62220201/162851540-ce0b211f-d96c-4f2c-aa92-108c4a0fb74e.png)

    5. The resulting `installer/build/setup.exe` can be renamed and published to a GitHub release!